### PR TITLE
Changes == operator to properly assign receipient address

### DIFF
--- a/ERC1155D.sol
+++ b/ERC1155D.sol
@@ -221,7 +221,7 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
             require(_owners[id] == from && amounts[i] < 2, "ERC1155: insufficient balance for transfer");
 
             if (amounts[i] == 1) {
-                _owners[id] == to;
+                _owners[id] = to;
             }  
         }
 


### PR DESCRIPTION
Fixes a typo that prevents tokens from being transferred when calling `_safeBatchTransferFrom`
Previously, was failing silently while passing all checks and emitting events while _not actually_ transferring the tokens. 

<img width="584" alt="image" src="https://user-images.githubusercontent.com/91582112/159166978-05718d0e-6b6b-4e56-9a0b-b8066374df87.png">
