### PR TITLE
add function for prepaying gas

### DIFF
--- a/contracts/ERC1155D.sol
+++ b/contracts/ERC1155D.sol
@@ -543,6 +543,23 @@ contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
         return array;
     }
 
+    function _prepayGas(uint256 start, uint256 end) internal {
+        require(end <= MAX_SUPPLY, "ERC1155D: end id exceeds maximum");
+
+        for (uint256 i = start; i < end; i++) {
+
+            bytes32 slotValue;
+            assembly {
+                slotValue := sload(add(_owners.slot, i))
+            }
+
+            bytes32 leftmostBitSetToOne = slotValue | bytes32(uint256(1) << 255);
+            assembly {
+                sstore(add(_owners.slot, i), leftmostBitSetToOne)
+            }
+        }
+    }
+
     function getOwnershipRecordOffChain() external view returns(address[MAX_SUPPLY] memory) {
         return _owners;
     }


### PR DESCRIPTION
### Summary
This function allows the devs (or a friendly whale, if desired) to prepay some of the gas for minting. Setting the `_owners` storage from address(0) to the owner costs 22,100 gas (20,000 storage + 2,100 cold access).

Addresses are 20 bytes long and don't use the left 12 bytes. This function sets the leftmost bit to 1. It leaves the other bits unaffected. This is to safeguard against someone overwriting addresses after mint.

This can result in net savings for the community if the gas is prepaid during a cheap period, and minting happens during an expensive period.

### Unit Economics
It costs 5,000 gas to go from non-zero to non-zero storage. By prepaying 22,100 gas, the minter saves 17,100 gas. It would seem that 5,000 gas is "wasted." However, this can result in a net gain for the community if done during a low congestion period. Example:

low gas period: 20 gwei
minting period: 100 gwei

Cost in Ether to prepay the storage slot: 20 * 22,100 / 1 billion = 0.000442
Cost in Ether to store new address during mint with prepayment:  100 * 5,000 / 1 billion = 0.0005
Cost in Ether to store new address during mint sans prepayment: 100 * 22,100 / 1 billion = 0.00221

Net savings: 0.00221 - 0.0005 - 0.000442 = 0.001268 Ether per address. This is substantial when thousands of addresses are involved.

### Implementation Details
If thousands of addresses are involved, the prepayment must be done in several transactions to avoid running into the gas block limit. Thus, `start` and `end` are provided to enable breaking up the transaction.

If the devs so desire, they can incentivize early minters by prepaying only the first hundred or so token ids.

### Credits
This methodology was inspired by [https://gastoken.io/](https://gastoken.io/)